### PR TITLE
Configure Swagger UI to sort operations alphabetically

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -110,6 +110,7 @@
         deepLinking: true,
         defaultModelRendering: 'model',
         validatorUrl: null,
+        operationsSorter: 'alpha',
         presets: [
             SwaggerUIBundle.presets.apis,
             SwaggerUIStandalonePreset


### PR DESCRIPTION
Change the default configuration of the swagger ui options to sort operations alphabetically.

![After](https://user-images.githubusercontent.com/66082932/152406375-4027269a-1bad-4953-8db5-f627ec10f0e3.png)









